### PR TITLE
Suppress the Duplicate declaration of hponcfg

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,8 +75,10 @@ class hpilo(
       timeout     => 0,
     }
     
-    package { 'hponcfg':
-      ensure => 'present',
+    if ! defined(Package['hponcfg']) {
+      package { 'hponcfg':
+        ensure => 'present',
+      }
     }
     # since the template accomodates dhcp and static there is no need to change the template file
     $ilotemplate = 'hpilo/iloconfig.erb'


### PR DESCRIPTION
Now you can use the puppet module hp_mcp and this one together without an error from puppet about hponcfg already being declared